### PR TITLE
fix: controller task FireAtPoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,11 +50,7 @@ Thumbs.db
 *.tmp
 *.bak
 *~
-
-
-CLAUDE.md
-.claude/
+__pycache__/
+*.py[cod]
 
 .task/
-
-.cursor/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -16,9 +16,11 @@ tasks:
     dir: '{{.TEST_DIR}}'
     cmds:
       - lua test_runner.lua
+      - python -m unittest test_export_harness_selene.py
     sources:
       - '{{.SRC_DIR}}/**/*.lua'
       - '{{.TEST_DIR}}/**/*.lua'
+      - '{{.TEST_DIR}}/**/*.py'
 
   test:single:
     desc: Run a single test file
@@ -34,6 +36,7 @@ tasks:
     sources:
       - '{{.SRC_DIR}}/**/*.lua'
       - '{{.TEST_DIR}}/**/*.lua'
+      - '{{.TEST_DIR}}/**/*.py'
     cmds:
       - task: test
 
@@ -48,9 +51,11 @@ tasks:
       - '{{.SRC_DIR}}/**/*.lua'
       - 'build/scripts/build_single_lua_release.py'
       - 'build/scripts/stamp_harness_version.py'
+      - 'build/scripts/export_harness_selene.py'
       - '.buildrc'
     generates:
       - 'dist/harness.lua'
+      - 'dist/harness-selene.yml'
 
   build:cd:
     desc: Build dist/harness.lua without formatting (CI/CD build)
@@ -62,9 +67,11 @@ tasks:
       - '{{.SRC_DIR}}/**/*.lua'
       - 'build/scripts/build_single_lua_release.py'
       - 'build/scripts/stamp_harness_version.py'
+      - 'build/scripts/export_harness_selene.py'
       - '.buildrc'
     generates:
       - 'dist/harness.lua'
+      - 'dist/harness-selene.yml'
 
   clean:
     desc: Clean build artifacts

--- a/build/scripts/export_harness_selene.py
+++ b/build/scripts/export_harness_selene.py
@@ -62,6 +62,9 @@ EXTRA_GLOBALS: Dict[str, Dict[str, Any]] = {
 
 PARAM_RE = re.compile(r"^\s*---@param\s+(\w+)\s+([^\s]+)")
 FUNC_DEF_RE = re.compile(r"^\s*function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+FUNC_SIGNATURE_RE = re.compile(
+    r"^\s*function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)"
+)
 
 
 @dataclass
@@ -135,15 +138,23 @@ def parse_lua_public_functions(lua_path: Path) -> List[ParsedFunction]:
     pending_param_types: List[str] = []
     results: List[ParsedFunction] = []
 
-    for line in lines:
+    line_index = 0
+    while line_index < len(lines):
+        line = lines[line_index]
         m_param = PARAM_RE.match(line)
         if m_param:
             # We only need the type order, name is not required for Selene
             type_str = m_param.group(2)
             pending_param_types.append(type_str)
+            line_index += 1
             continue
 
-        m_func = re.match(r"^\s*function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([^)]*)\)", line)
+        if FUNC_DEF_RE.match(line):
+            while ")" not in line and line_index + 1 < len(lines):
+                line_index += 1
+                line += " " + lines[line_index]
+
+        m_func = FUNC_SIGNATURE_RE.match(line)
         if m_func:
             fname = m_func.group(1)
             arglist = m_func.group(2).strip()
@@ -159,12 +170,14 @@ def parse_lua_public_functions(lua_path: Path) -> List[ParsedFunction]:
                 types_for_args.append("any")
             results.append(ParsedFunction(name=fname, arg_types=types_for_args))
             pending_param_types = []
+            line_index += 1
             continue
 
         # Reset pending when non-annotation non-blank encountered between blocks
         if pending_param_types and not line.strip().startswith("---") and not line.strip().startswith("--"):
             # a new chunk of code started; clear stale params to avoid mismatches
             pending_param_types = []
+        line_index += 1
 
     return results
 
@@ -221,6 +234,5 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-
 
 

--- a/dist/harness-selene.yml
+++ b/dist/harness-selene.yml
@@ -541,6 +541,34 @@ globals:
       required: false
   CreateRefuelingTask:
     args: []
+  CreateFACAttackGroupTask:
+    args:
+    - type: number
+    - type: number
+      required: false
+    - type: any
+      required: false
+    - type: bool
+      required: false
+    - type: number
+      required: false
+    - type: number
+      required: false
+    - type: number
+      required: false
+  CreateFireAtPointTask:
+    args:
+    - type: table
+    - type: number
+      required: false
+    - type: number
+      required: false
+    - type: bool
+      required: false
+    - type: number
+      required: false
+    - type: bool
+      required: false
   CreateHoldTask:
     args:
     - type: any
@@ -1732,6 +1760,96 @@ globals:
       required: false
     - type: table
     - type: number
+    - type: bool
+      required: false
+    - type: string
+      required: false
+  LineToAll:
+    args:
+    - type: number
+    - type: table
+    - type: table
+    - type: table
+      required: false
+    - type: number
+      required: false
+    - type: bool
+      required: false
+    - type: string
+      required: false
+  CircleToAll:
+    args:
+    - type: number
+    - type: table
+    - type: number
+    - type: table
+      required: false
+    - type: table
+      required: false
+    - type: number
+      required: false
+    - type: bool
+      required: false
+    - type: string
+      required: false
+  RectToAll:
+    args:
+    - type: number
+    - type: table
+    - type: table
+    - type: table
+      required: false
+    - type: table
+      required: false
+    - type: number
+      required: false
+    - type: bool
+      required: false
+    - type: string
+      required: false
+  QuadToAll:
+    args:
+    - type: number
+    - type: table
+    - type: table
+    - type: table
+    - type: table
+    - type: table
+      required: false
+    - type: table
+      required: false
+    - type: number
+      required: false
+    - type: bool
+      required: false
+    - type: string
+      required: false
+  TextToAll:
+    args:
+    - type: number
+    - type: string
+    - type: table
+    - type: table
+      required: false
+    - type: table
+      required: false
+    - type: number
+      required: false
+    - type: bool
+      required: false
+    - type: string
+      required: false
+  ArrowToAll:
+    args:
+    - type: number
+    - type: table
+    - type: table
+    - type: table
+      required: false
+    - type: table
+      required: false
+    - type: number
+      required: false
     - type: bool
       required: false
     - type: string

--- a/dist/harness.lua
+++ b/dist/harness.lua
@@ -1,7 +1,7 @@
--- harness: 0.7.1 loading...
+-- harness: 0.8.0 loading...
 -- ==== BEGIN: src/_header.lua ====
 -- Version
-HARNESS_VERSION = "0.7.1"
+HARNESS_VERSION = "0.8.0"
 -- Internal namespace for logger
 _HarnessInternal = _HarnessInternal or {}
 
@@ -4613,7 +4613,7 @@ function CreateFireAtPointTask(
     end
 
     local task = {
-        id = "fireAtPoint",
+        id = "FireAtPoint",
         params = {
             point = point,
             radius = radius or 50,

--- a/src/controller.lua
+++ b/src/controller.lua
@@ -1420,7 +1420,7 @@ function CreateFireAtPointTask(
     end
 
     local task = {
-        id = "fireAtPoint",
+        id = "FireAtPoint",
         params = {
             point = point,
             radius = radius or 50,

--- a/tests/test_controller.lua
+++ b/tests/test_controller.lua
@@ -72,7 +72,7 @@ function TestController:when_creating_tasks_should_match_expected_shape()
 
     local fire = CreateFireAtPointTask({ x = 0, y = 0, z = 0 }, 100)
     lu.assertNotNil(fire)
-    lu.assertEquals(fire.id, "fireAtPoint")
+    lu.assertEquals(fire.id, "FireAtPoint")
 
     local hold = CreateHoldTask()
     lu.assertNotNil(hold)
@@ -85,6 +85,12 @@ function TestController:when_creating_tasks_should_match_expected_shape()
     local wrapped = CreateWrappedAction({ id = "Script", params = {} }, true)
     lu.assertNotNil(wrapped)
     lu.assertEquals(wrapped.id, "WrappedAction")
+end
+
+function TestController:test_fire_at_point_uses_dcs_task_id()
+    local task = CreateFireAtPointTask({ x = 0, y = 0, z = 0 }, 100)
+
+    lu.assertEquals(task.id, "FireAtPoint")
 end
 
 function TestController:when_setting_common_options_should_call_setOption()

--- a/tests/test_export_harness_selene.py
+++ b/tests/test_export_harness_selene.py
@@ -1,0 +1,35 @@
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "build" / "scripts"))
+
+from export_harness_selene import parse_lua_public_functions
+
+
+class ExportHarnessSeleneTests(unittest.TestCase):
+    def test_parses_multiline_public_function(self):
+        source = """---@param point table
+---@param radius number?
+function CreateFireAtPointTask(
+    point,
+    radius
+)
+end
+"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source_path = Path(temp_dir) / "controller.lua"
+            source_path.write_text(source, encoding="utf-8")
+
+            functions = parse_lua_public_functions(source_path)
+
+        self.assertEqual(len(functions), 1)
+        self.assertEqual(functions[0].name, "CreateFireAtPointTask")
+        self.assertEqual(functions[0].arg_types, ["table", "number?"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR fixes harness support for DCS `FireAtPoint` tasks and ensures multiline Lua function declarations are included in the generated Selene definitions.

## Changes

- Use the exact DCS `FireAtPoint` task identifier.
- Parse multiline public function signatures in the Selene exporter.
- Add regression coverage for `FireAtPoint` and Selene generation.
- Generate Selene definitions as part of the standard build.
- Move personal ignore rules to local Git excludes and ignore Python cache files.

## Test plan

- [x] `task test` passes
- [x] `task build` passes
- [x] Tested in DCS through Medusa AAA area fire

## Changelog

- No changelog entry added.