### PR TITLE
feat: add GetUnitHealth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `GetUnitHealth` returns a validated current and initial life snapshot with derived alive and damaged states for a named unit.
+
 ### Changed
 
 ### Fixed

--- a/dist/harness-selene.yml
+++ b/dist/harness-selene.yml
@@ -2030,6 +2030,9 @@ globals:
   GetUnitPlayerName:
     args:
     - type: string
+  GetUnitHealth:
+    args:
+    - type: string
   GetUnitLife:
     args:
     - type: string

--- a/dist/harness.d.lua
+++ b/dist/harness.d.lua
@@ -88,6 +88,13 @@ local __HarnessLuaLsType5 = {}
 ---@field debug fun(message: string, caller?: string)
 local __HarnessLuaLsType6 = {}
 
+---@class UnitHealthSnapshot
+---@field CurrentLife number
+---@field InitialLife number?
+---@field IsAlive boolean
+---@field IsDamaged boolean?
+local __HarnessLuaLsType7 = {}
+
 ---@class Vec2
 ---@field x number DCS world X coordinate
 ---@field y number DCS world Z coordinate at the Vec2 boundary
@@ -101,7 +108,7 @@ local __HarnessLuaLsType6 = {}
 ---@field midpointTo fun(self: Vec2, other: Vec2): Vec2
 ---@field angleTo fun(self: Vec2, other: Vec2): number
 ---@field rotate fun(self: Vec2, angleDeg: number): Vec2
-local __HarnessLuaLsType7 = {}
+local __HarnessLuaLsType8 = {}
 
 ---@class Vec3
 ---@field x number DCS world X coordinate
@@ -120,7 +127,7 @@ local __HarnessLuaLsType7 = {}
 ---@field displace2D fun(self: Vec3, bearingDeg: number, distance: number): Vec3?
 ---@field midpointTo fun(self: Vec3, other: Vec3): Vec3
 ---@field angleTo fun(self: Vec3, other: Vec3): number
-local __HarnessLuaLsType8 = {}
+local __HarnessLuaLsType9 = {}
 
 ---@type string
 HARNESS_VERSION = nil
@@ -3288,6 +3295,12 @@ function GetUnitGroup(unitName) end
 ---@return string? playerName The player name if unit is player-controlled, nil otherwise
 --- Usage: local playerName = GetUnitPlayerName("Player")
 function GetUnitPlayerName(unitName) end
+
+--- Get a validated health snapshot for a named unit
+---@param unitName string The name of the unit
+---@return UnitHealthSnapshot? health Validated health state or nil
+--- Usage: local health = GetUnitHealth("Player")
+function GetUnitHealth(unitName) end
 
 --- Get unit life/health
 ---@param unitName string The name of the unit

--- a/dist/harness.lua
+++ b/dist/harness.lua
@@ -16840,6 +16840,12 @@ end
 ==================================================================================================
 ]]
 
+---@class UnitHealthSnapshot
+---@field CurrentLife number
+---@field InitialLife number?
+---@field IsAlive boolean
+---@field IsDamaged boolean?
+
 -- Ensure minimal cache structure in case environment hasn't initialized it yet
 _HarnessInternal = _HarnessInternal or {}
 _HarnessInternal.cache = _HarnessInternal.cache or {}
@@ -16851,6 +16857,10 @@ _HarnessInternal.cache.stats = _HarnessInternal.cache.stats
     or { hits = 0, misses = 0, evictions = 0 }
 
 local UnitInternal = {}
+
+function UnitInternal.isFiniteNumber(value)
+    return type(value) == "number" and value == value and value > -math.huge and value < math.huge
+end
 
 function UnitInternal.validVector(vector)
     return type(vector) == "table"
@@ -17294,6 +17304,47 @@ function GetUnitPlayerName(unitName)
     end
 
     return playerName
+end
+
+--- Get a validated health snapshot for a named unit
+---@param unitName string The name of the unit
+---@return UnitHealthSnapshot? health Validated health state or nil
+---@usage local health = GetUnitHealth("Player")
+function GetUnitHealth(unitName)
+    if type(unitName) ~= "string" or unitName == "" then
+        _HarnessInternal.log.error("GetUnitHealth requires non-empty unit name", "GetUnitHealth")
+        return nil
+    end
+
+    local unit = GetUnit(unitName)
+    if not unit then
+        return nil
+    end
+
+    local currentSuccess, currentLife = pcall(function()
+        return unit:getLife()
+    end)
+    local initialSuccess, initialLife = pcall(function()
+        return unit:getLife0()
+    end)
+    if not currentSuccess or not initialSuccess then
+        _HarnessInternal.log.error("Failed to get unit health", "GetUnitHealth")
+        return nil
+    end
+    if not UnitInternal.isFiniteNumber(currentLife) or currentLife < 0 then
+        _HarnessInternal.log.error("Invalid unit current life", "GetUnitHealth")
+        return nil
+    end
+
+    local health = {
+        CurrentLife = currentLife,
+        IsAlive = currentLife > 0,
+    }
+    if UnitInternal.isFiniteNumber(initialLife) and initialLife > 0 then
+        health.InitialLife = initialLife
+        health.IsDamaged = health.IsAlive and currentLife < initialLife
+    end
+    return health
 end
 
 --- Get unit life/health

--- a/src/unit.lua
+++ b/src/unit.lua
@@ -11,6 +11,12 @@ require("vector")
 require("terrain")
 require("conversion")
 
+---@class UnitHealthSnapshot
+---@field CurrentLife number
+---@field InitialLife number?
+---@field IsAlive boolean
+---@field IsDamaged boolean?
+
 -- Ensure minimal cache structure in case environment hasn't initialized it yet
 _HarnessInternal = _HarnessInternal or {}
 _HarnessInternal.cache = _HarnessInternal.cache or {}
@@ -22,6 +28,10 @@ _HarnessInternal.cache.stats = _HarnessInternal.cache.stats
     or { hits = 0, misses = 0, evictions = 0 }
 
 local UnitInternal = {}
+
+function UnitInternal.isFiniteNumber(value)
+    return type(value) == "number" and value == value and value > -math.huge and value < math.huge
+end
 
 function UnitInternal.validVector(vector)
     return type(vector) == "table"
@@ -465,6 +475,47 @@ function GetUnitPlayerName(unitName)
     end
 
     return playerName
+end
+
+--- Get a validated health snapshot for a named unit
+---@param unitName string The name of the unit
+---@return UnitHealthSnapshot? health Validated health state or nil
+---@usage local health = GetUnitHealth("Player")
+function GetUnitHealth(unitName)
+    if type(unitName) ~= "string" or unitName == "" then
+        _HarnessInternal.log.error("GetUnitHealth requires non-empty unit name", "GetUnitHealth")
+        return nil
+    end
+
+    local unit = GetUnit(unitName)
+    if not unit then
+        return nil
+    end
+
+    local currentSuccess, currentLife = pcall(function()
+        return unit:getLife()
+    end)
+    local initialSuccess, initialLife = pcall(function()
+        return unit:getLife0()
+    end)
+    if not currentSuccess or not initialSuccess then
+        _HarnessInternal.log.error("Failed to get unit health", "GetUnitHealth")
+        return nil
+    end
+    if not UnitInternal.isFiniteNumber(currentLife) or currentLife < 0 then
+        _HarnessInternal.log.error("Invalid unit current life", "GetUnitHealth")
+        return nil
+    end
+
+    local health = {
+        CurrentLife = currentLife,
+        IsAlive = currentLife > 0,
+    }
+    if UnitInternal.isFiniteNumber(initialLife) and initialLife > 0 then
+        health.InitialLife = initialLife
+        health.IsDamaged = health.IsAlive and currentLife < initialLife
+    end
+    return health
 end
 
 --- Get unit life/health

--- a/tests/test_unit.lua
+++ b/tests/test_unit.lua
@@ -8,6 +8,25 @@ package.path = package.path .. ";../src/?.lua"
 -- Create isolated test suite
 TestUnit = CreateIsolatedTestSuite("TestUnit", {})
 
+local function addHealthUnit(testCase, name, currentLife, initialLife)
+    local calls = { exists = 0, currentLife = 0, initialLife = 0 }
+    testCase.mockUnits[name] = {
+        isExist = function()
+            calls.exists = calls.exists + 1
+            return true
+        end,
+        getLife = function()
+            calls.currentLife = calls.currentLife + 1
+            return currentLife
+        end,
+        getLife0 = function()
+            calls.initialLife = calls.initialLife + 1
+            return initialLife
+        end,
+    }
+    return calls
+end
+
 function TestUnit:setUp()
     -- Load required modules
     require("mock_dcs")
@@ -593,6 +612,134 @@ function TestUnit:testGetUnitPlayerName_EmptyPlayerName()
     }
     local playerName = GetUnitPlayerName("EmptyPlayer")
     lu.assertEquals(playerName, "")
+end
+
+function TestUnit:testGetUnitHealthRejectsInvalidNamesBeforeLookup()
+    local lookupCalls = 0
+    Unit.getByName = function()
+        lookupCalls = lookupCalls + 1
+        return nil
+    end
+
+    lu.assertNil(GetUnitHealth())
+    lu.assertNil(GetUnitHealth(""))
+    lu.assertNil(GetUnitHealth(42))
+    lu.assertNil(GetUnitHealth(false))
+    lu.assertNil(GetUnitHealth({}))
+    lu.assertEquals(lookupCalls, 0)
+end
+
+function TestUnit:testGetUnitHealthReturnsSnapshotFromOneProtectedBoundaryRead()
+    local lookupCalls = 0
+    local calls = addHealthUnit(self, "HealthUnit", 75, 100)
+    Unit.getByName = function(name)
+        lookupCalls = lookupCalls + 1
+        return self.mockUnits[name]
+    end
+
+    lu.assertEquals(GetUnitHealth("HealthUnit"), {
+        CurrentLife = 75,
+        InitialLife = 100,
+        IsAlive = true,
+        IsDamaged = true,
+    })
+    lu.assertEquals(lookupCalls, 1)
+    lu.assertEquals(calls, { exists = 0, currentLife = 1, initialLife = 1 })
+end
+
+function TestUnit:testGetUnitHealthDerivesAliveAndDamagedStates()
+    local cases = {
+        {
+            name = "FullHealth",
+            currentLife = 100,
+            initialLife = 100,
+            alive = true,
+            damaged = false,
+        },
+        { name = "DeadHealth", currentLife = 0, initialLife = 100, alive = false, damaged = false },
+        {
+            name = "OverHealth",
+            currentLife = 101,
+            initialLife = 100,
+            alive = true,
+            damaged = false,
+        },
+    }
+
+    for _, case in ipairs(cases) do
+        addHealthUnit(self, case.name, case.currentLife, case.initialLife)
+        local snapshot = GetUnitHealth(case.name)
+        lu.assertEquals(snapshot.IsAlive, case.alive)
+        lu.assertEquals(snapshot.IsDamaged, case.damaged)
+    end
+end
+
+function TestUnit:testGetUnitHealthRejectsInvalidCurrentLife()
+    local cases = {
+        { name = "StringCurrent", value = "75" },
+        { name = "NilCurrent" },
+        { name = "NaNCurrent", value = 0 / 0 },
+        { name = "PositiveInfiniteCurrent", value = math.huge },
+        { name = "NegativeInfiniteCurrent", value = -math.huge },
+        { name = "NegativeCurrent", value = -1 },
+    }
+
+    for _, case in ipairs(cases) do
+        addHealthUnit(self, case.name, case.value, 100)
+        lu.assertNil(GetUnitHealth(case.name))
+    end
+end
+
+function TestUnit:testGetUnitHealthOmitsInvalidInitialLife()
+    local cases = {
+        { name = "StringInitial", value = "100" },
+        { name = "NilInitial" },
+        { name = "NaNInitial", value = 0 / 0 },
+        { name = "PositiveInfiniteInitial", value = math.huge },
+        { name = "NegativeInfiniteInitial", value = -math.huge },
+        { name = "ZeroInitial", value = 0 },
+        { name = "NegativeInitial", value = -1 },
+    }
+
+    for _, case in ipairs(cases) do
+        addHealthUnit(self, case.name, 50, case.value)
+        local snapshot = GetUnitHealth(case.name)
+        lu.assertEquals(snapshot.CurrentLife, 50)
+        lu.assertNil(snapshot.InitialLife)
+        lu.assertTrue(snapshot.IsAlive)
+        lu.assertNil(snapshot.IsDamaged)
+    end
+end
+
+function TestUnit:testGetUnitHealthContainsDcsApiExceptions()
+    Unit.getByName = function()
+        error("lookup failed")
+    end
+    lu.assertNil(GetUnitHealth("LookupError"))
+
+    self.mockUnits.CurrentLifeError = {
+        getLife = function()
+            error("current life failed")
+        end,
+        getLife0 = function()
+            return 100
+        end,
+    }
+    self.mockUnits.InitialLifeError = {
+        getLife = function()
+            return 50
+        end,
+        getLife0 = function()
+            error("initial life failed")
+        end,
+    }
+    Unit.getByName = function(name)
+        return self.mockUnits[name]
+    end
+
+    lu.assertNil(GetUnitHealth("MissingUnit"))
+    lu.assertNil(GetUnitHealth("CurrentLifeError"))
+    lu.assertNil(GetUnitHealth("InitialLifeError"))
 end
 
 -- GetUnitLife tests


### PR DESCRIPTION
## Summary

add GetUnitHealth

## Changes

- add GetUnitHealth

## Test plan

- [ ] `task test` passes
- [ ] `task build` passes
- [ ] Tested in DCS (if behavior change)

## Changelog

### Added

`GetUnitHealth` returns a validated current and initial life snapshot with derived alive and damaged states for a named unit.
